### PR TITLE
[exa-cursor-plugin]: follow Cursor plugin spec for native install

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -22,9 +22,5 @@
   "skills": "./skills/",
   "rules": "./rules/",
   "mcpServers": "mcp.json",
-  "commands": [
-    "commands/exa-setup.md",
-    "commands/exa-search.md",
-    "commands/exa-fetch.md"
-  ]
+  "commands": "./commands/"
 }

--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ Web search and content extraction for Cursor — powered by [Exa](https://exa.ai
 
 ## Install
 
-### Marketplace
+### From GitHub (recommended)
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace).
+In Cursor chat:
 
-### Local install (script)
+```
+/add-plugin exa-labs/exa-cursor-plugin
+```
 
-Clone the repo and run the install script:
+Or go to **Settings → Plugins → Add plugin** and paste:
+
+```
+https://github.com/exa-labs/exa-cursor-plugin
+```
+
+### Local folder
+
+Clone and copy into Cursor's local plugin directory:
 
 ```bash
 git clone https://github.com/exa-labs/exa-cursor-plugin.git
@@ -18,13 +28,13 @@ cd exa-cursor-plugin
 bash install.sh
 ```
 
-This copies the plugin to `~/.cursor/plugins/local/exa/` and registers it in `~/.claude/` so Cursor discovers it. Restart Cursor, then enable Exa under **Settings → Plugins**.
+This copies the plugin to `~/.cursor/plugins/local/exa/`. Restart Cursor afterward.
 
 To uninstall: `bash install.sh --uninstall`
 
-### Manual (MCP only)
+### MCP only
 
-If you only need the MCP tools (no skills, commands, or rules), add to `.cursor/mcp.json`:
+If you only want the MCP tools (no skills, commands, or rules), add to `.cursor/mcp.json`:
 
 ```json
 {
@@ -59,6 +69,17 @@ If you only need the MCP tools (no skills, commands, or rules), add to `.cursor/
 
 - `exa-awareness` — tells the agent to use Exa when it makes sense
 
+## Plugin Structure
+
+```
+.cursor-plugin/plugin.json   Plugin manifest
+skills/                      3 skills (auto-discovered)
+commands/                    3 slash commands (auto-discovered)
+rules/                       Awareness rule
+mcp.json                     MCP server config (remote)
+install.sh                   Local install helper
+```
+
 ## Local Development
 
 To iterate on the plugin itself:
@@ -72,24 +93,13 @@ cursor exa-cursor-plugin
 
 2. Skills, rules, and MCP config are auto-discovered from the repo's standard directories.
 
-3. To test as a real local plugin (with commands), install it:
+3. To test as a full plugin (with commands), copy to the local plugin dir:
 
 ```bash
 bash install.sh
 ```
 
-Re-run after each change to push updates to the local plugin directory.
-
-## Plugin Structure
-
-```
-.cursor-plugin/plugin.json   Plugin manifest
-.cursor/mcp.json             MCP server config (remote)
-skills/                      3 skills (auto-discovered)
-commands/                    3 slash commands
-rules/                       Awareness rule
-install.sh                   Local install/uninstall script
-```
+Re-run after each change to push updates.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,27 @@ Web search and content extraction for Cursor — powered by [Exa](https://exa.ai
 
 ## Install
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace), or add to `.cursor/mcp.json`:
+### Marketplace
+
+Install from the [Cursor Marketplace](https://cursor.com/marketplace).
+
+### Local install (script)
+
+Clone the repo and run the install script:
+
+```bash
+git clone https://github.com/exa-labs/exa-cursor-plugin.git
+cd exa-cursor-plugin
+bash install.sh
+```
+
+This copies the plugin to `~/.cursor/plugins/local/exa/`. Restart Cursor, then enable Exa under **Settings → Plugins**.
+
+To uninstall: `bash install.sh --uninstall`
+
+### Manual (MCP only)
+
+If you only need the MCP tools (no skills, commands, or rules), add to `.cursor/mcp.json`:
 
 ```json
 {
@@ -41,7 +61,7 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace), or add to
 
 ## Local Development
 
-To test the plugin locally without installing from the marketplace:
+To iterate on the plugin itself:
 
 1. Clone and open in Cursor:
 
@@ -50,17 +70,15 @@ git clone https://github.com/exa-labs/exa-cursor-plugin.git
 cursor exa-cursor-plugin
 ```
 
-2. Skills and rules are auto-discovered from the standard directories. Type `/` in the chat to verify the `exa-*` skills are listed.
+2. Skills, rules, and MCP config are auto-discovered from the repo's standard directories.
 
-3. Commands are not auto-discovered when testing locally. Symlink them into Cursor's project commands directory:
+3. To test as a real local plugin (with commands), install it:
 
 ```bash
-ln -s ../commands .cursor/commands
+bash install.sh
 ```
 
-Type `/` again — the `exa-*` commands should now appear alongside the skills.
-
-4. The MCP server config is in `.cursor/mcp.json`. Cursor will prompt you to authenticate with Exa on first use.
+Re-run after each change to push updates to the local plugin directory.
 
 ## Plugin Structure
 
@@ -70,6 +88,7 @@ Type `/` again — the `exa-*` commands should now appear alongside the skills.
 skills/                      3 skills (auto-discovered)
 commands/                    3 slash commands
 rules/                       Awareness rule
+install.sh                   Local install/uninstall script
 ```
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd exa-cursor-plugin
 bash install.sh
 ```
 
-This copies the plugin to `~/.cursor/plugins/local/exa/`. Restart Cursor, then enable Exa under **Settings → Plugins**.
+This copies the plugin to `~/.cursor/plugins/local/exa/` and registers it in `~/.claude/` so Cursor discovers it. Restart Cursor, then enable Exa under **Settings → Plugins**.
 
 To uninstall: `bash install.sh --uninstall`
 

--- a/commands/exa-fetch.md
+++ b/commands/exa-fetch.md
@@ -1,4 +1,5 @@
 ---
+name: exa-fetch
 description: "Read a webpage's content using Exa. Usage: /exa-fetch <url>"
 ---
 

--- a/commands/exa-search.md
+++ b/commands/exa-search.md
@@ -1,4 +1,5 @@
 ---
+name: exa-search
 description: "Search the web using Exa. Usage: /exa-search <query>"
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,28 +1,23 @@
 #!/usr/bin/env bash
-# install.sh — install or uninstall the Exa Cursor plugin locally
+# install.sh — copy the Exa plugin into Cursor's local plugin directory
 #
 # Usage:
-#   bash install.sh              # install plugin
-#   bash install.sh --uninstall  # remove plugin
+#   bash install.sh              # install
+#   bash install.sh --uninstall  # remove
 #
-# 1. Copies plugin files to ~/.cursor/plugins/local/exa/
-# 2. Registers the plugin in ~/.claude/plugins/installed_plugins.json
-# 3. Enables it in ~/.claude/settings.json
+# This is a convenience wrapper around Cursor's native local plugin path:
+#   ~/.cursor/plugins/local/exa/
 #
-# Requires python3 for JSON merging (ships with macOS/most Linux).
+# Prefer the native methods when possible:
+#   /add-plugin exa-labs/exa-cursor-plugin    (in Cursor chat)
+#   Settings → Plugins → Add plugin           (paste the GitHub URL)
 
 set -euo pipefail
 
 PLUGIN_NAME="exa"
-PLUGIN_ID="${PLUGIN_NAME}@local"
 PLUGIN_DIR="${HOME}/.cursor/plugins/local/${PLUGIN_NAME}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CLAUDE_DIR="${HOME}/.claude"
-CLAUDE_PLUGINS="${CLAUDE_DIR}/plugins/installed_plugins.json"
-CLAUDE_SETTINGS="${CLAUDE_DIR}/settings.json"
-
-# Components to copy (relative to repo root)
 COMPONENTS=(
   ".cursor-plugin"
   "skills"
@@ -31,91 +26,17 @@ COMPONENTS=(
   "mcp.json"
 )
 
-register_plugin() {
-  # Register in ~/.claude/plugins/installed_plugins.json (upsert, don't clobber)
-  python3 - "$CLAUDE_PLUGINS" "$PLUGIN_ID" "$PLUGIN_DIR" <<'PY'
-import json, os, sys
-path, pid, ipath = sys.argv[1], sys.argv[2], sys.argv[3]
-data = {}
-if os.path.exists(path):
-    try:
-        data = json.load(open(path))
-    except (json.JSONDecodeError, IOError):
-        data = {}
-plugins = data.get("plugins", {})
-entries = [e for e in plugins.get(pid, [])
-           if not (isinstance(e, dict) and e.get("scope") == "user")]
-entries.insert(0, {"scope": "user", "installPath": ipath})
-plugins[pid] = entries
-data["plugins"] = plugins
-os.makedirs(os.path.dirname(path), exist_ok=True)
-json.dump(data, open(path, "w"), indent=2)
-PY
-
-  # Enable in ~/.claude/settings.json (upsert, don't clobber)
-  python3 - "$CLAUDE_SETTINGS" "$PLUGIN_ID" <<'PY'
-import json, os, sys
-path, pid = sys.argv[1], sys.argv[2]
-data = {}
-if os.path.exists(path):
-    try:
-        data = json.load(open(path))
-    except (json.JSONDecodeError, IOError):
-        data = {}
-data.setdefault("enabledPlugins", {})[pid] = True
-os.makedirs(os.path.dirname(path), exist_ok=True)
-json.dump(data, open(path, "w"), indent=2)
-PY
-}
-
-unregister_plugin() {
-  # Remove from installed_plugins.json
-  if [ -f "$CLAUDE_PLUGINS" ]; then
-    python3 - "$CLAUDE_PLUGINS" "$PLUGIN_ID" <<'PY'
-import json, os, sys
-path, pid = sys.argv[1], sys.argv[2]
-try:
-    data = json.load(open(path))
-except (json.JSONDecodeError, IOError, FileNotFoundError):
-    sys.exit(0)
-plugins = data.get("plugins", {})
-plugins.pop(pid, None)
-data["plugins"] = plugins
-json.dump(data, open(path, "w"), indent=2)
-PY
-  fi
-
-  # Remove from settings.json
-  if [ -f "$CLAUDE_SETTINGS" ]; then
-    python3 - "$CLAUDE_SETTINGS" "$PLUGIN_ID" <<'PY'
-import json, os, sys
-path, pid = sys.argv[1], sys.argv[2]
-try:
-    data = json.load(open(path))
-except (json.JSONDecodeError, IOError, FileNotFoundError):
-    sys.exit(0)
-data.get("enabledPlugins", {}).pop(pid, None)
-json.dump(data, open(path, "w"), indent=2)
-PY
-  fi
-}
-
 uninstall() {
   if [ -d "$PLUGIN_DIR" ]; then
     rm -rf "$PLUGIN_DIR"
     echo "Removed ${PLUGIN_DIR}"
   else
-    echo "Plugin files not found — skipping."
+    echo "Plugin not found at ${PLUGIN_DIR} — nothing to remove."
   fi
-  unregister_plugin
-  echo "Unregistered from Cursor."
   echo "Restart Cursor to apply."
 }
 
 install() {
-  command -v python3 >/dev/null || { echo "python3 is required but not found."; exit 1; }
-
-  # Clean previous install
   [ -d "$PLUGIN_DIR" ] && rm -rf "$PLUGIN_DIR"
   mkdir -p "$PLUGIN_DIR"
 
@@ -124,15 +45,11 @@ install() {
     [ -e "$src" ] && cp -R "$src" "$PLUGIN_DIR/${component}"
   done
 
-  register_plugin
-
   echo "Installed to ${PLUGIN_DIR}"
-  echo "Registered in ${CLAUDE_PLUGINS}"
   echo ""
   echo "Next steps:"
-  echo "  1. Restart Cursor (or Cmd/Ctrl+Shift+P → 'Reload Window')"
-  echo "  2. Check Settings → Plugins — 'Exa' should be listed"
-  echo "  3. Check Settings → Tools & MCP — toggle Exa on"
+  echo "  1. Restart Cursor (or Cmd/Ctrl+Shift+P → Reload Window)"
+  echo "  2. The plugin should appear under Settings → Plugins"
 }
 
 case "${1:-}" in

--- a/install.sh
+++ b/install.sh
@@ -5,56 +5,134 @@
 #   bash install.sh              # install plugin
 #   bash install.sh --uninstall  # remove plugin
 #
-# Copies the plugin to ~/.cursor/plugins/local/exa/ so Cursor loads it
-# as a first-party plugin. No symlinks, no clobbering existing config.
+# 1. Copies plugin files to ~/.cursor/plugins/local/exa/
+# 2. Registers the plugin in ~/.claude/plugins/installed_plugins.json
+# 3. Enables it in ~/.claude/settings.json
+#
+# Requires python3 for JSON merging (ships with macOS/most Linux).
 
 set -euo pipefail
 
 PLUGIN_NAME="exa"
+PLUGIN_ID="${PLUGIN_NAME}@local"
 PLUGIN_DIR="${HOME}/.cursor/plugins/local/${PLUGIN_NAME}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CLAUDE_DIR="${HOME}/.claude"
+CLAUDE_PLUGINS="${CLAUDE_DIR}/plugins/installed_plugins.json"
+CLAUDE_SETTINGS="${CLAUDE_DIR}/settings.json"
 
 # Components to copy (relative to repo root)
 COMPONENTS=(
   ".cursor-plugin"
-  ".cursor"
   "skills"
   "commands"
   "rules"
   "mcp.json"
 )
 
+register_plugin() {
+  # Register in ~/.claude/plugins/installed_plugins.json (upsert, don't clobber)
+  python3 - "$CLAUDE_PLUGINS" "$PLUGIN_ID" "$PLUGIN_DIR" <<'PY'
+import json, os, sys
+path, pid, ipath = sys.argv[1], sys.argv[2], sys.argv[3]
+data = {}
+if os.path.exists(path):
+    try:
+        data = json.load(open(path))
+    except (json.JSONDecodeError, IOError):
+        data = {}
+plugins = data.get("plugins", {})
+entries = [e for e in plugins.get(pid, [])
+           if not (isinstance(e, dict) and e.get("scope") == "user")]
+entries.insert(0, {"scope": "user", "installPath": ipath})
+plugins[pid] = entries
+data["plugins"] = plugins
+os.makedirs(os.path.dirname(path), exist_ok=True)
+json.dump(data, open(path, "w"), indent=2)
+PY
+
+  # Enable in ~/.claude/settings.json (upsert, don't clobber)
+  python3 - "$CLAUDE_SETTINGS" "$PLUGIN_ID" <<'PY'
+import json, os, sys
+path, pid = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.exists(path):
+    try:
+        data = json.load(open(path))
+    except (json.JSONDecodeError, IOError):
+        data = {}
+data.setdefault("enabledPlugins", {})[pid] = True
+os.makedirs(os.path.dirname(path), exist_ok=True)
+json.dump(data, open(path, "w"), indent=2)
+PY
+}
+
+unregister_plugin() {
+  # Remove from installed_plugins.json
+  if [ -f "$CLAUDE_PLUGINS" ]; then
+    python3 - "$CLAUDE_PLUGINS" "$PLUGIN_ID" <<'PY'
+import json, os, sys
+path, pid = sys.argv[1], sys.argv[2]
+try:
+    data = json.load(open(path))
+except (json.JSONDecodeError, IOError, FileNotFoundError):
+    sys.exit(0)
+plugins = data.get("plugins", {})
+plugins.pop(pid, None)
+data["plugins"] = plugins
+json.dump(data, open(path, "w"), indent=2)
+PY
+  fi
+
+  # Remove from settings.json
+  if [ -f "$CLAUDE_SETTINGS" ]; then
+    python3 - "$CLAUDE_SETTINGS" "$PLUGIN_ID" <<'PY'
+import json, os, sys
+path, pid = sys.argv[1], sys.argv[2]
+try:
+    data = json.load(open(path))
+except (json.JSONDecodeError, IOError, FileNotFoundError):
+    sys.exit(0)
+data.get("enabledPlugins", {}).pop(pid, None)
+json.dump(data, open(path, "w"), indent=2)
+PY
+  fi
+}
+
 uninstall() {
   if [ -d "$PLUGIN_DIR" ]; then
     rm -rf "$PLUGIN_DIR"
     echo "Removed ${PLUGIN_DIR}"
   else
-    echo "Nothing to remove — plugin not installed."
+    echo "Plugin files not found — skipping."
   fi
-  echo "Restart Cursor to apply changes."
+  unregister_plugin
+  echo "Unregistered from Cursor."
+  echo "Restart Cursor to apply."
 }
 
 install() {
-  # Clean previous install
-  if [ -d "$PLUGIN_DIR" ]; then
-    rm -rf "$PLUGIN_DIR"
-  fi
+  command -v python3 >/dev/null || { echo "python3 is required but not found."; exit 1; }
 
+  # Clean previous install
+  [ -d "$PLUGIN_DIR" ] && rm -rf "$PLUGIN_DIR"
   mkdir -p "$PLUGIN_DIR"
 
   for component in "${COMPONENTS[@]}"; do
     src="${SCRIPT_DIR}/${component}"
-    if [ -e "$src" ]; then
-      cp -R "$src" "$PLUGIN_DIR/${component}"
-    fi
+    [ -e "$src" ] && cp -R "$src" "$PLUGIN_DIR/${component}"
   done
 
+  register_plugin
+
   echo "Installed to ${PLUGIN_DIR}"
+  echo "Registered in ${CLAUDE_PLUGINS}"
   echo ""
   echo "Next steps:"
   echo "  1. Restart Cursor (or Cmd/Ctrl+Shift+P → 'Reload Window')"
-  echo "  2. Go to Cursor Settings → Plugins and confirm 'Exa' is listed"
-  echo "  3. Go to Cursor Settings → Tools & MCP and toggle Exa on"
+  echo "  2. Check Settings → Plugins — 'Exa' should be listed"
+  echo "  3. Check Settings → Tools & MCP — toggle Exa on"
 }
 
 case "${1:-}" in

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install.sh — install or uninstall the Exa Cursor plugin locally
+#
+# Usage:
+#   bash install.sh              # install plugin
+#   bash install.sh --uninstall  # remove plugin
+#
+# Copies the plugin to ~/.cursor/plugins/local/exa/ so Cursor loads it
+# as a first-party plugin. No symlinks, no clobbering existing config.
+
+set -euo pipefail
+
+PLUGIN_NAME="exa"
+PLUGIN_DIR="${HOME}/.cursor/plugins/local/${PLUGIN_NAME}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Components to copy (relative to repo root)
+COMPONENTS=(
+  ".cursor-plugin"
+  ".cursor"
+  "skills"
+  "commands"
+  "rules"
+  "mcp.json"
+)
+
+uninstall() {
+  if [ -d "$PLUGIN_DIR" ]; then
+    rm -rf "$PLUGIN_DIR"
+    echo "Removed ${PLUGIN_DIR}"
+  else
+    echo "Nothing to remove — plugin not installed."
+  fi
+  echo "Restart Cursor to apply changes."
+}
+
+install() {
+  # Clean previous install
+  if [ -d "$PLUGIN_DIR" ]; then
+    rm -rf "$PLUGIN_DIR"
+  fi
+
+  mkdir -p "$PLUGIN_DIR"
+
+  for component in "${COMPONENTS[@]}"; do
+    src="${SCRIPT_DIR}/${component}"
+    if [ -e "$src" ]; then
+      cp -R "$src" "$PLUGIN_DIR/${component}"
+    fi
+  done
+
+  echo "Installed to ${PLUGIN_DIR}"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Restart Cursor (or Cmd/Ctrl+Shift+P → 'Reload Window')"
+  echo "  2. Go to Cursor Settings → Plugins and confirm 'Exa' is listed"
+  echo "  3. Go to Cursor Settings → Tools & MCP and toggle Exa on"
+}
+
+case "${1:-}" in
+  --uninstall) uninstall ;;
+  *)           install ;;
+esac


### PR DESCRIPTION
## Summary

Makes the repo follow the Cursor plugin spec so it works with native install methods — no custom scripts required.

**What changed:**

- `plugin.json`: switched `commands` from explicit file list to `"./commands/"` directory auto-discovery (consistent with `skills` and `rules`)
- `commands/exa-search.md`, `commands/exa-fetch.md`: added missing `name` frontmatter (required by plugin spec)
- `install.sh`: simplified to just `cp -R` into `~/.cursor/plugins/local/exa/` (the [official native path](https://github.com/cursor/plugin-template/issues/4#issuecomment-2730941936) per Cursor engineering). Removed the `~/.claude/` JSON registration complexity
- `README.md`: leads with native install methods

**Install methods now supported:**

1. `/add-plugin exa-labs/exa-cursor-plugin` in Cursor chat
2. Settings → Plugins → Add plugin → paste GitHub URL
3. `bash install.sh` (copies to `~/.cursor/plugins/local/exa/`)
4. MCP-only via `.cursor/mcp.json`

## Review & Testing Checklist for Human

- [ ] Try `/add-plugin exa-labs/exa-cursor-plugin` in Cursor chat — confirm plugin loads with skills, commands, rules, MCP
- [ ] Try `bash install.sh` → restart Cursor → confirm plugin appears under Settings → Plugins
- [ ] Verify `/exa-search`, `/exa-fetch`, `/exa-setup` commands are discoverable
- [ ] Verify `exa-web-search`, `exa-fetch`, `exa-best-practices` skills are available
- [ ] Verify `exa-awareness` rule applies (agent suggests Exa for web lookups)

### Notes

- Symlinks to `~/.cursor/plugins/local/` are [bugged](https://github.com/cursor/plugins/issues/35), so the install script uses `cp -R`
- The `/add-plugin` method installs directly from GitHub and is the cleanest path

Link to Devin session: https://app.devin.ai/sessions/59fa96213d72403799e543cfc36d43f5
Requested by: @MiguelAtExa